### PR TITLE
fix: update default Gemini model to gemini-2.5-flash

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -59,7 +59,7 @@ const DEFAULT_SETTINGS: GeminiChatbotSettings = {
 	ragStoreName: null,
 	ragSyncedFiles: {},
 	// Model configuration defaults
-	modelName: "gemini-2.0-flash-exp",
+	modelName: "gemini-2.5-flash",
 	temperature: 1.0,
 	topK: 40,
 	topP: 0.95,
@@ -2930,13 +2930,13 @@ class GeminiChatbotSettingTab extends PluginSettingTab {
 		// Model name setting
 		new Setting(containerEl)
 			.setName("Model Name")
-			.setDesc("The Gemini model to use (e.g., gemini-2.0-flash-exp, gemini-1.5-pro, gemini-1.5-flash)")
+			.setDesc("The Gemini model to use (e.g., gemini-2.5-flash, gemini-2.0-flash, gemini-1.5-pro)")
 			.addText((text) => {
 				text
-					.setPlaceholder("gemini-2.0-flash-exp")
+					.setPlaceholder("gemini-2.5-flash")
 					.setValue(this.plugin.settings.modelName)
 					.onChange(async (value) => {
-						this.plugin.settings.modelName = value || "gemini-2.0-flash-exp";
+						this.plugin.settings.modelName = value || "gemini-2.5-flash";
 						await this.plugin.saveSettings();
 						this.plugin.initializeGeminiService();
 					});

--- a/src/services/GeminiService.ts
+++ b/src/services/GeminiService.ts
@@ -41,7 +41,7 @@ export class GeminiService {
     constructor(apiKey: string, config?: ModelConfig) {
         this.apiKey = apiKey;
         this.config = config || {
-            modelName: "gemini-2.0-flash-exp",
+            modelName: "gemini-2.5-flash",
             temperature: 1.0,
             topK: 40,
             topP: 0.95,


### PR DESCRIPTION
## Summary

- Replaces deprecated `gemini-2.0-flash-exp` default model with `gemini-2.5-flash`
- Updates default in `DEFAULT_SETTINGS` (main.ts) and `GeminiService` constructor fallback
- Updates settings UI placeholder, description, and onChange fallback to reflect new default

## Root Cause

`gemini-2.0-flash-exp` is no longer available via the Gemini API (`v1beta`), causing new users to hit an immediate error on first launch without any indication it's a model issue (not an API key issue).

Closes #23

## Test plan

- [x] Fresh install with no prior settings → plugin uses `gemini-2.5-flash` by default and chat works
- [x] Settings page shows `gemini-2.5-flash` as placeholder and examples
- [x] Existing users with a saved model name are unaffected (saved value takes precedence over default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)