### PR TITLE
feat: copy text from chat

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -631,35 +631,30 @@ export default class GeminiChatbotPlugin extends Plugin {
 		messageEl.addClass(`gemini-message-${message.role}`);
 
 		if (message.role === "bot") {
-			// Button group
-			const actionButtons = messageEl.createEl("div", { cls: "message-action-buttons" });
+			// Render markdown content
+			const contentEl = messageEl.createEl("div", { cls: "message-content" });
+			await MarkdownRenderer.render(this.app, message.content, contentEl, "", this);
 
-			const clipboardButton = actionButtons.createEl("button", { cls: "copy-response-button", attr: { "aria-label": "Copy to clipboard" } });
+			// Action bar below content — always visible
+			const actionBar = messageEl.createEl("div", { cls: "message-action-bar" });
+
+			const clipboardButton = actionBar.createEl("button", { cls: "message-action-btn" });
 			setIcon(clipboardButton, "copy");
 			clipboardButton.addEventListener("click", async () => {
 				await navigator.clipboard.writeText(message.content);
 				setIcon(clipboardButton, "check");
-				setTimeout(() => { setIcon(clipboardButton, "copy"); }, 2000);
+				setTimeout(() => setIcon(clipboardButton, "copy"), 2000);
 			});
 
-			const copyButton = actionButtons.createEl("button", { cls: "copy-response-button", attr: { "aria-label": "Copy to new note" } });
-			setIcon(copyButton, "file-plus");
-
-			copyButton.addEventListener("click", async () => {
-				// Generate creative title based on content
+			const noteButton = actionBar.createEl("button", { cls: "message-action-btn" });
+			setIcon(noteButton, "file-plus");
+			noteButton.addEventListener("click", async () => {
 				const title = this.generateNoteTitle(message.content);
-				const file = await this.app.vault.create(
-					`${title}.md`,
-					message.content
-				);
+				const file = await this.app.vault.create(`${title}.md`, message.content);
 				const leaf = this.app.workspace.getLeaf(false);
 				await leaf.openFile(file);
 				new Notice("Response copied to new note!");
 			});
-
-			// Render markdown into a separate div so actionButtons isn't overwritten
-			const contentEl = messageEl.createEl("div", { cls: "message-content" });
-			await MarkdownRenderer.render(this.app, message.content, contentEl, "", this);
 		} else {
 			// For user messages, just show the visible part
 			const visibleContent = this.stripContextFromMessage(
@@ -2611,56 +2606,40 @@ ${surroundingLines.join('\n')}
 					messageEl.className = `gemini-message-${message.role}`;
 
 					if (message.role === "bot") {
-						// Button group
-						const actionButtons = document.createElement("div");
-						actionButtons.className = "message-action-buttons";
+						const contentEl = document.createElement("div");
+						contentEl.className = "message-content";
+						messageEl.appendChild(contentEl);
+						await MarkdownRenderer.render(this.app, message.content, contentEl, "", this);
+
+						const actionBar = document.createElement("div");
+						actionBar.className = "message-action-bar";
 
 						const clipboardButton = document.createElement("button");
-						clipboardButton.className = "copy-response-button";
-						clipboardButton.setAttribute("aria-label", "Copy to clipboard");
+						clipboardButton.className = "message-action-btn";
 						setIcon(clipboardButton, "copy");
 						clipboardButton.addEventListener("click", async () => {
 							await navigator.clipboard.writeText(message.content);
 							setIcon(clipboardButton, "check");
-							setTimeout(() => { setIcon(clipboardButton, "copy"); }, 2000);
+							setTimeout(() => setIcon(clipboardButton, "copy"), 2000);
 						});
-						actionButtons.appendChild(clipboardButton);
+						actionBar.appendChild(clipboardButton);
 
-						const copyButton = document.createElement("button");
-						copyButton.className = "copy-response-button";
-						copyButton.setAttribute("aria-label", "Copy to new note");
-						setIcon(copyButton, "file-plus");
-
-						copyButton.addEventListener("click", async () => {
+						const noteButton = document.createElement("button");
+						noteButton.className = "message-action-btn";
+						setIcon(noteButton, "file-plus");
+						noteButton.addEventListener("click", async () => {
 							try {
 								const title = this.generateNoteTitle(message.content);
-								const file = await this.app.vault.create(
-									`${title}.md`,
-									message.content
-								);
+								const file = await this.app.vault.create(`${title}.md`, message.content);
 								const leaf = this.app.workspace.getLeaf(false);
 								await leaf.openFile(file);
 								new Notice("Response copied to new note!");
 							} catch (error) {
-								console.error("Failed to create note:", error);
 								new Notice("Failed to create note");
 							}
 						});
-						actionButtons.appendChild(copyButton);
-
-						messageEl.appendChild(actionButtons);
-
-						// Render markdown into a separate div so actionButtons isn't overwritten
-						const contentEl = document.createElement("div");
-						contentEl.className = "message-content";
-						messageEl.appendChild(contentEl);
-						await MarkdownRenderer.render(
-							this.app,
-							message.content,
-							contentEl,
-							"",
-							this
-						);
+						actionBar.appendChild(noteButton);
+						messageEl.appendChild(actionBar);
 					} else {
 						// For user messages, show the visible content
 						const visibleContent = this.stripContextFromMessage(

--- a/main.ts
+++ b/main.ts
@@ -1462,6 +1462,11 @@ export default class GeminiChatbotPlugin extends Plugin {
 			DEFAULT_SETTINGS,
 			await this.loadData()
 		);
+		// Migrate deprecated model name for existing users
+		if (this.settings.modelName === "gemini-2.0-flash-exp") {
+			this.settings.modelName = "gemini-2.5-flash";
+			await this.saveSettings();
+		}
 	}
 
 	async saveSettings() {

--- a/main.ts
+++ b/main.ts
@@ -631,8 +631,20 @@ export default class GeminiChatbotPlugin extends Plugin {
 		messageEl.addClass(`gemini-message-${message.role}`);
 
 		if (message.role === "bot") {
-			// Add copy button
-			const copyButton = messageEl.createEl("button", {
+			// Button group
+			const actionButtons = messageEl.createEl("div", { cls: "message-action-buttons" });
+
+			const clipboardButton = actionButtons.createEl("button", {
+				text: "Copy",
+				cls: "copy-response-button",
+			});
+			clipboardButton.addEventListener("click", async () => {
+				await navigator.clipboard.writeText(message.content);
+				clipboardButton.textContent = "Copied!";
+				setTimeout(() => { clipboardButton.textContent = "Copy"; }, 2000);
+			});
+
+			const copyButton = actionButtons.createEl("button", {
 				text: "Copy to new note",
 				cls: "copy-response-button",
 			});
@@ -2594,7 +2606,20 @@ ${surroundingLines.join('\n')}
 					messageEl.className = `gemini-message-${message.role}`;
 
 					if (message.role === "bot") {
-						// Add copy button for bot messages
+						// Button group
+						const actionButtons = document.createElement("div");
+						actionButtons.className = "message-action-buttons";
+
+						const clipboardButton = document.createElement("button");
+						clipboardButton.textContent = "Copy";
+						clipboardButton.className = "copy-response-button";
+						clipboardButton.addEventListener("click", async () => {
+							await navigator.clipboard.writeText(message.content);
+							clipboardButton.textContent = "Copied!";
+							setTimeout(() => { clipboardButton.textContent = "Copy"; }, 2000);
+						});
+						actionButtons.appendChild(clipboardButton);
+
 						const copyButton = document.createElement("button");
 						copyButton.textContent = "Copy to new note";
 						copyButton.className = "copy-response-button";
@@ -2614,8 +2639,9 @@ ${surroundingLines.join('\n')}
 								new Notice("Failed to create note");
 							}
 						});
+						actionButtons.appendChild(copyButton);
 
-						messageEl.appendChild(copyButton);
+						messageEl.appendChild(actionButtons);
 
 						// Render markdown for bot messages
 						await MarkdownRenderer.render(

--- a/main.ts
+++ b/main.ts
@@ -1109,7 +1109,7 @@ export default class GeminiChatbotPlugin extends Plugin {
 
 		const actionsMenuButton = document.createElement("button");
 		actionsMenuButton.addClass("actions-menu-button");
-		setIcon(actionsMenuButton, "sparkles");
+		setIcon(actionsMenuButton, "sliders-horizontal");
 		actionsMenuButton.title = "Actions";
 
 		const actionsMenuDropdown = document.createElement("div");
@@ -1117,7 +1117,7 @@ export default class GeminiChatbotPlugin extends Plugin {
 		actionsMenuDropdown.style.display = "none";
 
 		const actions = [
-			{ id: "prompts", label: "Custom Prompts", icon: "sparkles", description: "Use saved prompts" },
+			{ id: "prompts", label: "Custom Prompts", icon: "layout-list", description: "Use saved prompts" },
 			{ id: "mention", label: "Mention File", icon: "at-sign", description: "Reference a file" },
 			{ id: "insert", label: "Insert Mode", icon: "pin", description: "Insert at cursor" }
 		];
@@ -1131,6 +1131,9 @@ export default class GeminiChatbotPlugin extends Plugin {
 			iconSpan.addClass("action-icon");
 			setIcon(iconSpan, action.icon);
 
+			const textDiv = document.createElement("div");
+			textDiv.addClass("action-text");
+
 			const labelSpan = document.createElement("span");
 			labelSpan.addClass("action-label");
 			labelSpan.textContent = action.label;
@@ -1139,9 +1142,10 @@ export default class GeminiChatbotPlugin extends Plugin {
 			descSpan.addClass("action-description");
 			descSpan.textContent = action.description;
 
+			textDiv.appendChild(labelSpan);
+			textDiv.appendChild(descSpan);
 			option.appendChild(iconSpan);
-			option.appendChild(labelSpan);
-			option.appendChild(descSpan);
+			option.appendChild(textDiv);
 			actionsMenuDropdown.appendChild(option);
 		});
 
@@ -1163,8 +1167,8 @@ export default class GeminiChatbotPlugin extends Plugin {
 
 		const modes = [
 			{ id: "normal", label: "Normal", icon: "message-circle", description: "Standard chat" },
-			{ id: "rag", label: "RAG", icon: "database", description: "Search vault" },
-			{ id: "web", label: "Web Search", icon: "globe", description: "Search web" }
+			{ id: "rag", label: "Vault Search", icon: "database", description: "Search your vault" },
+			{ id: "web", label: "Web Search", icon: "globe", description: "Search the web" }
 		];
 
 		modes.forEach(mode => {
@@ -1176,6 +1180,9 @@ export default class GeminiChatbotPlugin extends Plugin {
 			iconSpan.addClass("mode-icon");
 			setIcon(iconSpan, mode.icon);
 
+			const textDiv = document.createElement("div");
+			textDiv.addClass("mode-text");
+
 			const labelSpan = document.createElement("span");
 			labelSpan.addClass("mode-label");
 			labelSpan.textContent = mode.label;
@@ -1184,9 +1191,10 @@ export default class GeminiChatbotPlugin extends Plugin {
 			descSpan.addClass("mode-description");
 			descSpan.textContent = mode.description;
 
+			textDiv.appendChild(labelSpan);
+			textDiv.appendChild(descSpan);
 			option.appendChild(iconSpan);
-			option.appendChild(labelSpan);
-			option.appendChild(descSpan);
+			option.appendChild(textDiv);
 			modeDropdown.appendChild(option);
 		});
 

--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { App, Notice, Plugin, PluginSettingTab, Setting, MarkdownView, Editor } from "obsidian";
+import { App, Notice, Plugin, PluginSettingTab, Setting, MarkdownView, Editor, setIcon } from "obsidian";
 import { GeminiService, WebSearchResponse } from "./src/services/GeminiService";
 import { RAGService } from "./src/services/RAGService";
 import { LanguageSelectionModal } from "./src/modals/LanguageSelectionModal";
@@ -634,20 +634,16 @@ export default class GeminiChatbotPlugin extends Plugin {
 			// Button group
 			const actionButtons = messageEl.createEl("div", { cls: "message-action-buttons" });
 
-			const clipboardButton = actionButtons.createEl("button", {
-				text: "Copy",
-				cls: "copy-response-button",
-			});
+			const clipboardButton = actionButtons.createEl("button", { cls: "copy-response-button", attr: { "aria-label": "Copy to clipboard" } });
+			setIcon(clipboardButton, "copy");
 			clipboardButton.addEventListener("click", async () => {
 				await navigator.clipboard.writeText(message.content);
-				clipboardButton.textContent = "Copied!";
-				setTimeout(() => { clipboardButton.textContent = "Copy"; }, 2000);
+				setIcon(clipboardButton, "check");
+				setTimeout(() => { setIcon(clipboardButton, "copy"); }, 2000);
 			});
 
-			const copyButton = actionButtons.createEl("button", {
-				text: "Copy to new note",
-				cls: "copy-response-button",
-			});
+			const copyButton = actionButtons.createEl("button", { cls: "copy-response-button", attr: { "aria-label": "Copy to new note" } });
+			setIcon(copyButton, "file-plus");
 
 			copyButton.addEventListener("click", async () => {
 				// Generate creative title based on content
@@ -661,8 +657,9 @@ export default class GeminiChatbotPlugin extends Plugin {
 				new Notice("Response copied to new note!");
 			});
 
-			// Directly render markdown using the correct API
-			await MarkdownRenderer.render(this.app, message.content, messageEl, "", this);
+			// Render markdown into a separate div so actionButtons isn't overwritten
+			const contentEl = messageEl.createEl("div", { cls: "message-content" });
+			await MarkdownRenderer.render(this.app, message.content, contentEl, "", this);
 		} else {
 			// For user messages, just show the visible part
 			const visibleContent = this.stripContextFromMessage(
@@ -1104,7 +1101,7 @@ export default class GeminiChatbotPlugin extends Plugin {
 		// Send button
 		const sendButton = document.createElement("button");
 		sendButton.addClass("send-button");
-		sendButton.textContent = "↑";
+		setIcon(sendButton, "arrow-up");
 
 		// Actions dropdown (prompts, mention, insert)
 		const actionsMenuContainer = document.createElement("div");
@@ -1112,7 +1109,7 @@ export default class GeminiChatbotPlugin extends Plugin {
 
 		const actionsMenuButton = document.createElement("button");
 		actionsMenuButton.addClass("actions-menu-button");
-		actionsMenuButton.textContent = "✨";
+		setIcon(actionsMenuButton, "sparkles");
 		actionsMenuButton.title = "Actions";
 
 		const actionsMenuDropdown = document.createElement("div");
@@ -1120,9 +1117,9 @@ export default class GeminiChatbotPlugin extends Plugin {
 		actionsMenuDropdown.style.display = "none";
 
 		const actions = [
-			{ id: "prompts", label: "Custom Prompts", icon: "✨", description: "Use saved prompts" },
-			{ id: "mention", label: "Mention File", icon: "@", description: "Reference a file" },
-			{ id: "insert", label: "Insert Mode", icon: "📍", description: "Insert at cursor" }
+			{ id: "prompts", label: "Custom Prompts", icon: "sparkles", description: "Use saved prompts" },
+			{ id: "mention", label: "Mention File", icon: "at-sign", description: "Reference a file" },
+			{ id: "insert", label: "Insert Mode", icon: "pin", description: "Insert at cursor" }
 		];
 
 		actions.forEach(action => {
@@ -1132,7 +1129,7 @@ export default class GeminiChatbotPlugin extends Plugin {
 
 			const iconSpan = document.createElement("span");
 			iconSpan.addClass("action-icon");
-			iconSpan.textContent = action.icon;
+			setIcon(iconSpan, action.icon);
 
 			const labelSpan = document.createElement("span");
 			labelSpan.addClass("action-label");
@@ -1157,7 +1154,7 @@ export default class GeminiChatbotPlugin extends Plugin {
 
 		const modeButton = document.createElement("button");
 		modeButton.addClass("mode-selector-button");
-		modeButton.textContent = "💬";
+		setIcon(modeButton, "message-circle");
 		modeButton.title = "Select chat mode";
 
 		const modeDropdown = document.createElement("div");
@@ -1165,9 +1162,9 @@ export default class GeminiChatbotPlugin extends Plugin {
 		modeDropdown.style.display = "none";
 
 		const modes = [
-			{ id: "normal", label: "Normal", icon: "💬", description: "Standard chat" },
-			{ id: "rag", label: "RAG", icon: "🧠", description: "Search vault" },
-			{ id: "web", label: "Web Search", icon: "🌐", description: "Search web" }
+			{ id: "normal", label: "Normal", icon: "message-circle", description: "Standard chat" },
+			{ id: "rag", label: "RAG", icon: "database", description: "Search vault" },
+			{ id: "web", label: "Web Search", icon: "globe", description: "Search web" }
 		];
 
 		modes.forEach(mode => {
@@ -1177,7 +1174,7 @@ export default class GeminiChatbotPlugin extends Plugin {
 
 			const iconSpan = document.createElement("span");
 			iconSpan.addClass("mode-icon");
-			iconSpan.textContent = mode.icon;
+			setIcon(iconSpan, mode.icon);
 
 			const labelSpan = document.createElement("span");
 			labelSpan.addClass("mode-label");
@@ -1707,12 +1704,12 @@ ${surroundingLines.join('\n')}
 
 		if (insertButton) {
 			if (this.insertMode) {
-				insertButton.textContent = "📍✓";
+				setIcon(insertButton, "pin");
 				insertButton.style.backgroundColor = "var(--interactive-accent)";
 				insertButton.style.color = "var(--text-on-accent)";
 				insertButton.title = "Insert mode ON - AI responses will be inserted at cursor";
 			} else {
-				insertButton.textContent = "📍";
+				setIcon(insertButton, "pin");
 				insertButton.style.backgroundColor = "";
 				insertButton.style.color = "";
 				insertButton.title = "Insert AI response at cursor position";
@@ -1748,21 +1745,21 @@ ${surroundingLines.join('\n')}
 		if (modeButton) {
 			switch (mode) {
 				case "normal":
-					modeButton.textContent = "💬";
+					setIcon(modeButton, "message-circle");
 					modeButton.style.backgroundColor = "";
 					modeButton.style.color = "";
 					modeButton.title = "Mode: Normal";
 					new Notice("Normal mode");
 					break;
 				case "rag":
-					modeButton.textContent = "🧠";
+					setIcon(modeButton, "database");
 					modeButton.style.backgroundColor = "var(--interactive-accent)";
 					modeButton.style.color = "var(--text-on-accent)";
 					modeButton.title = "Mode: RAG (Searching vault)";
 					new Notice("RAG mode ON - Searching entire vault");
 					break;
 				case "web":
-					modeButton.textContent = "🌐";
+					setIcon(modeButton, "globe");
 					modeButton.style.backgroundColor = "var(--interactive-accent)";
 					modeButton.style.color = "var(--text-on-accent)";
 					modeButton.title = "Mode: Web Search";
@@ -2611,18 +2608,20 @@ ${surroundingLines.join('\n')}
 						actionButtons.className = "message-action-buttons";
 
 						const clipboardButton = document.createElement("button");
-						clipboardButton.textContent = "Copy";
 						clipboardButton.className = "copy-response-button";
+						clipboardButton.setAttribute("aria-label", "Copy to clipboard");
+						setIcon(clipboardButton, "copy");
 						clipboardButton.addEventListener("click", async () => {
 							await navigator.clipboard.writeText(message.content);
-							clipboardButton.textContent = "Copied!";
-							setTimeout(() => { clipboardButton.textContent = "Copy"; }, 2000);
+							setIcon(clipboardButton, "check");
+							setTimeout(() => { setIcon(clipboardButton, "copy"); }, 2000);
 						});
 						actionButtons.appendChild(clipboardButton);
 
 						const copyButton = document.createElement("button");
-						copyButton.textContent = "Copy to new note";
 						copyButton.className = "copy-response-button";
+						copyButton.setAttribute("aria-label", "Copy to new note");
+						setIcon(copyButton, "file-plus");
 
 						copyButton.addEventListener("click", async () => {
 							try {
@@ -2643,11 +2642,14 @@ ${surroundingLines.join('\n')}
 
 						messageEl.appendChild(actionButtons);
 
-						// Render markdown for bot messages
+						// Render markdown into a separate div so actionButtons isn't overwritten
+						const contentEl = document.createElement("div");
+						contentEl.className = "message-content";
+						messageEl.appendChild(contentEl);
 						await MarkdownRenderer.render(
 							this.app,
 							message.content,
-							messageEl,
+							contentEl,
 							"",
 							this
 						);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vault-ai",
-	"version": "1.0.9",
+	"version": "1.0.11",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vault-ai",
-			"version": "1.0.9",
+			"version": "1.0.11",
 			"license": "MIT",
 			"dependencies": {
 				"@google/genai": "^1.29.1",
@@ -538,6 +538,7 @@
 			"integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@eslint/object-schema": "^2.1.7",
 				"debug": "^4.3.1",
@@ -553,6 +554,7 @@
 			"integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@eslint/core": "^0.17.0"
 			},
@@ -566,6 +568,7 @@
 			"integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.15"
 			},
@@ -579,6 +582,7 @@
 			"integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
@@ -603,6 +607,7 @@
 			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 4"
 			}
@@ -613,6 +618,7 @@
 			"integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
@@ -626,6 +632,7 @@
 			"integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
@@ -636,6 +643,7 @@
 			"integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@eslint/core": "^0.17.0",
 				"levn": "^0.4.1"
@@ -680,6 +688,7 @@
 			"integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">=18.18.0"
 			}
@@ -690,6 +699,7 @@
 			"integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@humanfs/core": "^0.19.1",
 				"@humanwhocodes/retry": "^0.4.0"
@@ -704,6 +714,7 @@
 			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">=12.22"
 			},
@@ -718,6 +729,7 @@
 			"integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">=18.18"
 			},
@@ -775,7 +787,8 @@
 			"resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
 			"integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@pkgjs/parseargs": {
 			"version": "0.11.0",
@@ -809,7 +822,8 @@
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
 			"integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@types/node": {
 			"version": "16.18.126",
@@ -1085,7 +1099,6 @@
 			"integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.54.0",
 				"@typescript-eslint/types": "8.54.0",
@@ -1281,6 +1294,7 @@
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
@@ -1300,6 +1314,7 @@
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -1340,7 +1355,8 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true,
-			"license": "Python-2.0"
+			"license": "Python-2.0",
+			"peer": true
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
@@ -1383,6 +1399,7 @@
 			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -1413,6 +1430,7 @@
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -1423,6 +1441,7 @@
 			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
@@ -1457,14 +1476,16 @@
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/crelt": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
 			"integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -1511,7 +1532,8 @@
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/eastasianwidth": {
 			"version": "0.2.0",
@@ -1582,6 +1604,7 @@
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -1656,6 +1679,7 @@
 			"integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"dependencies": {
 				"esrecurse": "^4.3.0",
 				"estraverse": "^5.2.0"
@@ -1686,6 +1710,7 @@
 			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 4"
 			}
@@ -1696,6 +1721,7 @@
 			"integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"dependencies": {
 				"acorn": "^8.15.0",
 				"acorn-jsx": "^5.3.2",
@@ -1714,6 +1740,7 @@
 			"integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
 			"dev": true,
 			"license": "BSD-3-Clause",
+			"peer": true,
 			"dependencies": {
 				"estraverse": "^5.1.0"
 			},
@@ -1727,6 +1754,7 @@
 			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
 			"dev": true,
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"dependencies": {
 				"estraverse": "^5.2.0"
 			},
@@ -1740,6 +1768,7 @@
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 			"dev": true,
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"engines": {
 				"node": ">=4.0"
 			}
@@ -1750,6 +1779,7 @@
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true,
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -1765,21 +1795,24 @@
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/fdir": {
 			"version": "6.5.0",
@@ -1828,6 +1861,7 @@
 			"integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"flat-cache": "^4.0.0"
 			},
@@ -1841,6 +1875,7 @@
 			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"locate-path": "^6.0.0",
 				"path-exists": "^4.0.0"
@@ -1858,6 +1893,7 @@
 			"integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"flatted": "^3.2.9",
 				"keyv": "^4.5.4"
@@ -1871,7 +1907,8 @@
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
 			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
 			"dev": true,
-			"license": "ISC"
+			"license": "ISC",
+			"peer": true
 		},
 		"node_modules/foreground-child": {
 			"version": "3.3.1",
@@ -1995,6 +2032,7 @@
 			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
 			"dev": true,
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"is-glob": "^4.0.3"
 			},
@@ -2008,6 +2046,7 @@
 			"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -2061,6 +2100,7 @@
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -2094,6 +2134,7 @@
 			"integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"parent-module": "^1.0.0",
 				"resolve-from": "^4.0.0"
@@ -2111,6 +2152,7 @@
 			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.8.19"
 			}
@@ -2121,6 +2163,7 @@
 			"integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -2140,6 +2183,7 @@
 			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"is-extglob": "^2.1.1"
 			},
@@ -2174,6 +2218,7 @@
 			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -2195,21 +2240,24 @@
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
 			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/jwa": {
 			"version": "2.0.1",
@@ -2238,6 +2286,7 @@
 			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"json-buffer": "3.0.1"
 			}
@@ -2248,6 +2297,7 @@
 			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"prelude-ls": "^1.2.1",
 				"type-check": "~0.4.0"
@@ -2262,6 +2312,7 @@
 			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"p-locate": "^5.0.0"
 			},
@@ -2277,7 +2328,8 @@
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/lru-cache": {
 			"version": "10.4.3",
@@ -2291,6 +2343,7 @@
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
 			"license": "ISC",
+			"peer": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -2389,6 +2442,7 @@
 			"integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"deep-is": "^0.1.3",
 				"fast-levenshtein": "^2.0.6",
@@ -2407,6 +2461,7 @@
 			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"yocto-queue": "^0.1.0"
 			},
@@ -2423,6 +2478,7 @@
 			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"p-limit": "^3.0.2"
 			},
@@ -2445,6 +2501,7 @@
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"callsites": "^3.0.0"
 			},
@@ -2458,6 +2515,7 @@
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -2493,7 +2551,6 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -2507,6 +2564,7 @@
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">= 0.8.0"
 			}
@@ -2517,6 +2575,7 @@
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -2527,6 +2586,7 @@
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -2693,6 +2753,7 @@
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=8"
 			},
@@ -2705,7 +2766,8 @@
 			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
 			"integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
@@ -2713,6 +2775,7 @@
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
 			},
@@ -2750,6 +2813,7 @@
 			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"prelude-ls": "^1.2.1"
 			},
@@ -2763,7 +2827,6 @@
 			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -2778,6 +2841,7 @@
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
@@ -2787,7 +2851,8 @@
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
 			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/web-streams-polyfill": {
 			"version": "3.3.3",
@@ -2819,6 +2884,7 @@
 			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -2944,6 +3010,7 @@
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vault-ai",
-	"version": "1.0.10",
+	"version": "1.0.11",
 	"description": "Transform your note-taking with an intelligent AI assistant powered by Google's Gemini AI.",
 	"main": "main.js",
 	"scripts": {

--- a/styles.css
+++ b/styles.css
@@ -910,13 +910,17 @@
 	justify-content: flex-end;
 }
 
+.message-action-buttons {
+	display: flex;
+	gap: 4px;
+}
+
 .copy-response-button {
 	background: var(--chat-bot-bg);
 	color: var(--chat-text);
 	border: 1px solid var(--chat-border);
 	padding: 4px 8px;
 	border-radius: 4px;
-	border: none;
 	cursor: pointer;
 	font-size: 12px;
 	transition: opacity 0.2s;
@@ -1133,25 +1137,29 @@
 	position: relative;
 }
 
-/* Copy button */
-.copy-response-button {
+/* Copy button group */
+.message-action-buttons {
 	position: absolute;
 	top: 8px;
 	right: 8px;
+	display: flex;
+	gap: 4px;
+	opacity: 0;
+	transition: opacity 0.2s;
+}
+
+.gemini-message-bot:hover .message-action-buttons {
+	opacity: 1;
+}
+
+.copy-response-button {
 	background: var(--chat-bot-bg);
 	color: var(--chat-text);
 	border: 1px solid var(--chat-border);
 	padding: 4px 8px;
 	border-radius: 4px;
-	border: none;
 	cursor: pointer;
 	font-size: 12px;
-	opacity: 0;
-	transition: opacity 0.2s;
-}
-
-.gemini-message-bot:hover .copy-response-button {
-	opacity: 1;
 }
 
 /* Direct markdown styling */

--- a/styles.css
+++ b/styles.css
@@ -508,9 +508,9 @@
 
 .gemini-message-bot {
 	width: 100%;
-	background: var(--chat-bot-bg);
-	border: 1px solid var(--chat-border);
-	padding: 16px;
+	background: none;
+	border: none;
+	padding: 8px 0;
 	position: relative;
 	flex-shrink: 0;
 	min-height: min-content;
@@ -933,10 +933,9 @@
 
 /* Response Formatting */
 .gemini-message-bot {
-	background: var(--chat-bot-bg);
-	border: 1px solid var(--chat-border);
-	border-radius: 8px;
-	overflow: hidden;
+	background: none;
+	border: none;
+	border-radius: 0;
 }
 
 .response-header {
@@ -945,36 +944,6 @@
 	border-bottom: 1px solid var(--background-modifier-border);
 	display: flex;
 	justify-content: flex-end;
-}
-
-.message-action-buttons {
-	display: flex;
-	gap: 4px;
-}
-
-.copy-response-button {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	width: 26px;
-	height: 26px;
-	background: var(--chat-bot-bg);
-	color: var(--text-muted);
-	border: 1px solid var(--chat-border);
-	border-radius: 4px;
-	cursor: pointer;
-	padding: 0;
-	transition: color 0.15s, background 0.15s;
-}
-
-.copy-response-button:hover {
-	color: var(--text-normal);
-	background: var(--background-modifier-hover);
-}
-
-.copy-response-button svg {
-	width: 14px;
-	height: 14px;
 }
 
 .response-content {
@@ -1026,26 +995,6 @@
 	color: var(--text-muted);
 }
 
-/* Copy button styling */
-.copy-response-button {
-	position: absolute;
-	top: 8px;
-	right: 8px;
-	background: var(--chat-bot-bg);
-	color: var(--chat-text);
-	border: 1px solid var(--chat-border);
-	padding: 4px 8px;
-	border-radius: 4px;
-	border: none;
-	cursor: pointer;
-	font-size: 12px;
-	opacity: 0;
-	transition: opacity 0.2s;
-}
-
-.gemini-message-bot:hover .copy-response-button {
-	opacity: 1;
-}
 
 /* Direct markdown content styling */
 .gemini-message-bot h1,
@@ -1173,55 +1122,48 @@
 	background: var(--background-secondary);
 }
 
-/* Bot message styling */
+/* Bot message styling — no bubble, flat like ChatGPT */
 .gemini-message-bot {
 	width: 100%;
-	background: var(--chat-bot-bg);
-	border: 1px solid var(--chat-border);
-	border-radius: 12px;
-	margin: 8px 0;
-	padding: 16px;
+	background: none;
+	border: none;
+	border-radius: 0;
+	margin: 4px 0;
+	padding: 8px 0;
 	position: relative;
 }
 
-/* Copy button group */
-.message-action-buttons {
-	position: absolute;
-	top: 8px;
-	right: 8px;
+
+/* Action bar below bot messages — always visible, ChatGPT style */
+.message-action-bar {
 	display: flex;
-	gap: 4px;
-	opacity: 0;
-	transition: opacity 0.2s;
+	gap: 2px;
+	margin-top: 8px;
 }
 
-.gemini-message-bot:hover .message-action-buttons {
-	opacity: 1;
-}
-
-.copy-response-button {
+.message-action-btn {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	width: 26px;
-	height: 26px;
-	background: var(--background-primary);
-	color: var(--text-muted);
-	border: 1px solid var(--background-modifier-border);
+	width: 24px;
+	height: 24px;
+	background: none;
+	color: var(--text-faint);
+	border: none;
 	border-radius: 4px;
 	cursor: pointer;
 	padding: 0;
-	transition: color 0.15s, background 0.15s;
+	transition: color 0.15s;
 }
 
-.copy-response-button:hover {
+.message-action-btn:hover {
 	color: var(--text-normal);
-	background: var(--background-modifier-hover);
+	background: none;
 }
 
-.copy-response-button svg {
-	width: 14px;
-	height: 14px;
+.message-action-btn svg {
+	width: 15px;
+	height: 15px;
 }
 
 /* Direct markdown styling */

--- a/styles.css
+++ b/styles.css
@@ -916,18 +916,28 @@
 }
 
 .copy-response-button {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 26px;
+	height: 26px;
 	background: var(--chat-bot-bg);
-	color: var(--chat-text);
+	color: var(--text-muted);
 	border: 1px solid var(--chat-border);
-	padding: 4px 8px;
 	border-radius: 4px;
 	cursor: pointer;
-	font-size: 12px;
-	transition: opacity 0.2s;
+	padding: 0;
+	transition: color 0.15s, background 0.15s;
 }
 
 .copy-response-button:hover {
-	opacity: 0.9;
+	color: var(--text-normal);
+	background: var(--background-modifier-hover);
+}
+
+.copy-response-button svg {
+	width: 14px;
+	height: 14px;
 }
 
 .response-content {
@@ -1153,13 +1163,28 @@
 }
 
 .copy-response-button {
-	background: var(--chat-bot-bg);
-	color: var(--chat-text);
-	border: 1px solid var(--chat-border);
-	padding: 4px 8px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 26px;
+	height: 26px;
+	background: var(--background-primary);
+	color: var(--text-muted);
+	border: 1px solid var(--background-modifier-border);
 	border-radius: 4px;
 	cursor: pointer;
-	font-size: 12px;
+	padding: 0;
+	transition: color 0.15s, background 0.15s;
+}
+
+.copy-response-button:hover {
+	color: var(--text-normal);
+	background: var(--background-modifier-hover);
+}
+
+.copy-response-button svg {
+	width: 14px;
+	height: 14px;
 }
 
 /* Direct markdown styling */

--- a/styles.css
+++ b/styles.css
@@ -504,6 +504,8 @@
 	background-color: var(--interactive-accent);
 	color: var(--text-on-accent);
 	border-bottom-right-radius: 4px;
+	user-select: text;
+	-webkit-user-select: text;
 }
 
 .gemini-message-bot {

--- a/styles.css
+++ b/styles.css
@@ -321,9 +321,9 @@
 }
 
 .actions-menu-option {
-	padding: 12px 16px;
+	padding: 10px 14px;
 	cursor: pointer;
-	transition: background 0.2s;
+	transition: background 0.15s;
 	display: flex;
 	align-items: center;
 	gap: 12px;
@@ -339,19 +339,34 @@
 }
 
 .action-icon {
-	font-size: 18px;
-	width: 24px;
-	text-align: center;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	flex-shrink: 0;
+	color: var(--text-muted);
+}
+
+.action-icon svg {
+	width: 16px;
+	height: 16px;
+}
+
+.action-text {
+	display: flex;
+	flex-direction: column;
+	gap: 1px;
 }
 
 .action-label {
+	font-size: 13px;
 	font-weight: 500;
-	flex: 1;
+	color: var(--text-normal);
 }
 
 .action-description {
 	font-size: 11px;
-	opacity: 0.6;
 	color: var(--text-muted);
 }
 
@@ -396,9 +411,9 @@
 }
 
 .mode-option {
-	padding: 12px 16px;
+	padding: 10px 14px;
 	cursor: pointer;
-	transition: background 0.2s;
+	transition: background 0.15s;
 	display: flex;
 	align-items: center;
 	gap: 12px;
@@ -418,26 +433,46 @@
 	color: var(--text-on-accent);
 }
 
+.mode-option.active .mode-icon,
 .mode-option.active .mode-description {
 	color: var(--text-on-accent);
-	opacity: 0.8;
+	opacity: 0.85;
 }
 
 .mode-icon {
-	font-size: 18px;
-	width: 24px;
-	text-align: center;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	flex-shrink: 0;
+	color: var(--text-muted);
+}
+
+.mode-icon svg {
+	width: 16px;
+	height: 16px;
+}
+
+.mode-text {
+	display: flex;
+	flex-direction: column;
+	gap: 1px;
 }
 
 .mode-label {
+	font-size: 13px;
 	font-weight: 500;
-	flex: 1;
+	color: var(--text-normal);
 }
 
 .mode-description {
 	font-size: 11px;
-	opacity: 0.6;
 	color: var(--text-muted);
+}
+
+.mode-option.active .mode-label {
+	color: var(--text-on-accent);
 }
 
 /* Add to existing styles.css */
@@ -479,6 +514,8 @@
 	position: relative;
 	flex-shrink: 0;
 	min-height: min-content;
+	user-select: text;
+	-webkit-user-select: text;
 }
 
 .gemini-message-error {


### PR DESCRIPTION
## Summary

- Adds **Copy to clipboard** and **Copy to new note** icon buttons below each bot message
- ChatGPT-style flat layout — no bubble, clean response area
- Lucide icons throughout the UI (send, mode selector, actions menu, dropdowns)
- Dropdown items show label + description stacked vertically
- Text in bot messages is now selectable
- Auto-migrates deprecated `gemini-2.0-flash-exp` model to `gemini-2.5-flash` for existing users

Closes #30

## Test plan

- [x] Copy button copies raw markdown to clipboard
- [x] File-plus button creates a new note with the response content
- [x] Both buttons are always visible below bot messages
- [x] Text in responses can be highlighted and copied manually
- [x] Users with old model saved get auto-migrated on plugin load

🤖 Generated with [Claude Code](https://claude.com/claude-code)